### PR TITLE
Pydocstyle can be applied to all content

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
   hooks:
   - id: pydocstyle
     additional_dependencies: [toml]
-    exclude: "tests/"
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0


### PR DESCRIPTION
Tests folder does not exist, so no need to exclude it in the pydocstyle configuration.