### PR TITLE
Docs: minor tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,16 +50,16 @@ Documentation
 -------------
 
 Documentation for the latest stable release of PyGranta is hosted at
-`PyGranta documentation <https://grantami.docs.pyansys.com/version/dev/index.html#>`_.
+`PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/index.html#>`_.
 The documentation has four sections:
 
-- `Getting started <https://grantami.docs.pyansys.com/version/dev/getting_started.html#>`_: Describes
+- `Getting started <https://grantami.docs.pyansys.com/version/stable/getting_started.html#>`_: Describes
   how to install PyGranta in user mode.
-- `User guide <https://grantami.docs.pyansys.com/version/dev/user_guide.html>`_: Describes how to
+- `User guide <https://grantami.docs.pyansys.com/version/stable/user_guide.html>`_: Describes how to
   use PyGranta.
-- `API reference <https://grantami.docs.pyansys.com/version/dev/api.html>`_: Provides API member descriptions
+- `API reference <https://grantami.docs.pyansys.com/version/stable/api.html>`_: Provides API member descriptions
   and usage examples.
-- `Examples <https://grantami.docs.pyansys.com/version/dev/examples.html>`_: Provides examples showing
+- `Examples <https://grantami.docs.pyansys.com/version/stable/examples.html>`_: Provides examples showing
   end-to-end workflows for using PyGranta.
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,6 @@
 
-PyGranta metapackage
-####################
+PyGranta metapackage |version|
+##############################
 
 Welcome to the PyGranta metapackage documentation. This page lists the PyAnsys packages
 that provide integration with Granta MI services. For guidance on installing, using, or
@@ -21,7 +21,7 @@ Packages
 
 .. grid:: 3
 
-    .. grid-item-card:: PyGranta BoM Analytics: documetnation
+    .. grid-item-card:: PyGranta BoM Analytics: documentation
       :link: https://bomanalytics.grantami.docs.pyansys.com/
       :text-align: center
       :class-title: pyansys-card-title


### PR DESCRIPTION
Closes #21 

Target stable version of the docs in README links.
Add package version number on docs homepage.

This will mean that the links on the README won't work until we properly release version 2023.2, as there are no stable versions published yet.

To be cherrypicked onto the release branch.