### PR TITLE
Set sphinx user agent

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,3 +87,8 @@ source_suffix = ".rst"
 
 # The master toctree document.
 master_doc = "index"
+
+user_agent = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"
+)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,8 @@
 """Sphinx documentation configuration file."""
+
 from datetime import datetime
 import os
+import platform
 
 from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 
@@ -88,7 +90,11 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
+# Set a custom user agent for linkcheck purposes
+python_implementation = platform.python_implementation()
+python_version = platform.python_version()
+os_version = platform.platform()
 user_agent = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"
+    f"PyGranta Sphinx Documentation/{release} {python_implementation}/{python_version} "
+    f"({os_version})"
 )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -95,6 +95,5 @@ python_implementation = platform.python_implementation()
 python_version = platform.python_version()
 os_version = platform.platform()
 user_agent = (
-    f"PyGranta Sphinx Documentation/{release} {python_implementation}/{python_version} "
-    f"({os_version})"
+    f"PyGranta Documentation/{release} {python_implementation}/{python_version} ({os_version})"
 )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,8 +1,6 @@
 """Sphinx documentation configuration file."""
-
 from datetime import datetime
 import os
-import platform
 
 from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 
@@ -91,9 +89,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # Set a custom user agent for linkcheck purposes
-python_implementation = platform.python_implementation()
-python_version = platform.python_version()
-os_version = platform.platform()
 user_agent = (
-    f"PyGranta Documentation/{release} {python_implementation}/{python_version} ({os_version})"
+    "(Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"
 )


### PR DESCRIPTION
It looks like requests to ansys.com are dropped if they have a user agent that looks like a web scraper. Builds are currently failing for this reason, but they seem to succeed if a browser-esque user agent is specified instead.

Already reviewed and approved here: #47 