### PR TITLE
Add reusable workflow

### DIFF
--- a/.github/workflows/check-concurrent-workflows.yml
+++ b/.github/workflows/check-concurrent-workflows.yml
@@ -1,0 +1,48 @@
+name: "Check concurrent workflows"
+on:
+  workflow_call:
+    outputs:
+      active-runs:
+        description: "Whether there are active runs ('true'|'false')"
+        value: ${{ jobs.checkWorkflowRuns.outputs.result }}
+
+jobs:
+  checkWorkflowRuns:
+    name: "Check current workflow runs"
+    runs-on: [ ubuntu-latest ]
+    outputs:
+      result: ${{ steps.check-workflow-runs.outputs.result }}
+    steps:
+      - name: "Get runs"
+        id: check-workflow-runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          function Check-For-Ongoing-Runs {
+            $currentRepository = "${{ github.repository }}"
+            $currentWorkflow = "${{ github.workflow }}"
+            $currentRunNumber = "${{ github.run_number }}"
+
+            $workflows =
+            @{Repository='ansys/grantami-recordlists'; Name='CI'},
+            @{Repository='ansys/grantami-bomanalytics'; Name='Pre-merge checks'}
+
+            foreach ($workflow in $workflows) {
+                if (($workflow.Repository -eq $currentRepository) -and ($workflow.Name -eq $currentWorkflow)) {
+                  $query = '[.[] | select(.status | test("(in_progress)|(queued)|(requested)|(waiting)|(pending)")) | select(.number != ' + $currentRunNumber + ')] | length'
+                } else {
+                  $query = '[.[] | select(.status | test("(in_progress)|(queued)|(requested)|(waiting)|(pending)"))] | length'
+                }
+                $count = gh run list -R $workflow.Repository -w $workflow.Name --json number,status -q $query
+                Write-Host $workflow.Repository $workflow.Name: $count runs in progress
+                if ($count -gt 0){
+                    return "true"
+                }
+            }
+            return "false"
+          }
+
+          $result = Check-For-Ongoing-Runs
+          echo "result=$result" >> $env:GITHUB_OUTPUT
+          echo "Active runs: $result"


### PR DESCRIPTION
Adds a reusable workflow definition that other PyGranta repos can use to check wether there are active workflows amongst a pre-defined list of repos and workflows.

Copied from https://github.com/ansys/grantami-bomanalytics/blob/main/.github/workflows/check-concurrent-workflows.yml, which is currenly used for BomAnalytics and RecordLists.