### PR TITLE
Add grantami-jobqueue CI to list of workflows

### DIFF
--- a/.github/workflows/check-concurrent-workflows.yml
+++ b/.github/workflows/check-concurrent-workflows.yml
@@ -25,6 +25,7 @@ jobs:
             $currentRunNumber = "${{ github.run_number }}"
 
             $workflows =
+            @{Repository='ansys/grantami-jobqueue'; Name='CI'},
             @{Repository='ansys/grantami-recordlists'; Name='CI'},
             @{Repository='ansys/grantami-bomanalytics'; Name='Pre-merge checks'}
 


### PR DESCRIPTION
Closes https://github.com/ansys/grantami-jobqueue/issues/70

Add grantami-jobqueue CI workflow to list of workflows to check.

The grantami-jobqueue repo is now public, so this change should work.