### PR TITLE
Skip Ansys URLs in sphinx linkcheck

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -94,3 +94,6 @@ user_agent = (
     "(Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"
 )
+
+# Ignore ansys links for linkcheck
+linkcheck_ignore = ["https://www.ansys.com/"]


### PR DESCRIPTION
Despite the custom user agent, sometimes checks on the https://ansys.com url still fail. This PR just skips checks for that domain.