### PR TITLE
Update dependencies for 2024.2 release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -128,13 +128,13 @@ oidc = ["keyring (>=22,<25)", "requests_auth (>=6,<8)"]
 
 [[package]]
 name = "ansys-sphinx-theme"
-version = "0.16.0"
+version = "0.16.5"
 description = "A theme devised by ANSYS, Inc. for Sphinx documentation."
 optional = false
 python-versions = "<4,>=3.9"
 files = [
-    {file = "ansys_sphinx_theme-0.16.0-py3-none-any.whl", hash = "sha256:594061e401c6a038e3e5c8a837e8af361d2c5376d44e024c921504751ff35215"},
-    {file = "ansys_sphinx_theme-0.16.0.tar.gz", hash = "sha256:3fd85b2cfb801bda700ba6fe96e795a93c393fabd80ddda3006b18781c100901"},
+    {file = "ansys_sphinx_theme-0.16.5-py3-none-any.whl", hash = "sha256:3546b1a9fde6aebbe5d1a762470248d1e3a24d70c26c6eb334d6a9f1b986e5c9"},
+    {file = "ansys_sphinx_theme-0.16.5.tar.gz", hash = "sha256:21e23524e92be937b8e6b2efc1eaa6b1afa3d500d48d4260ef4596337fdc7732"},
 ]
 
 [package.dependencies]
@@ -144,8 +144,8 @@ pydata-sphinx-theme = ">=0.14,<0.15"
 Sphinx = ">=4.2.0"
 
 [package.extras]
-autoapi = ["sphinx-autoapi (==3.0.0a4)", "sphinx-design (==0.5.0)", "sphinx-jinja (==2.0.2)"]
-doc = ["PyGitHub (==2.3.0)", "Sphinx (==7.3.7)", "numpydoc (==1.7.0)", "requests (==2.31.0)", "sphinx-copybutton (==0.5.2)", "sphinx-design (==0.5.0)", "sphinx-jinja (==2.0.2)", "sphinx-notfound-page (==1.0.0)"]
+autoapi = ["sphinx-autoapi (==3.1.1)", "sphinx-design (==0.6.0)", "sphinx-jinja (==2.0.2)"]
+doc = ["PyGitHub (==2.3.0)", "Sphinx (==7.3.7)", "numpydoc (==1.7.0)", "requests (==2.32.2)", "sphinx-copybutton (==0.5.2)", "sphinx-design (==0.6.0)", "sphinx-jinja (==2.0.2)", "sphinx-notfound-page (==1.0.2)"]
 
 [[package]]
 name = "babel"

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,13 +128,13 @@ oidc = ["keyring (>=22,<25)", "requests_auth (>=6,<8)"]
 
 [[package]]
 name = "ansys-sphinx-theme"
-version = "0.15.2"
+version = "0.16.0"
 description = "A theme devised by ANSYS, Inc. for Sphinx documentation."
 optional = false
 python-versions = "<4,>=3.9"
 files = [
-    {file = "ansys_sphinx_theme-0.15.2-py3-none-any.whl", hash = "sha256:302a3b2ecb8e7632f9f52492746adacff85dbf8cd46922510c4ae4c5019f8d79"},
-    {file = "ansys_sphinx_theme-0.15.2.tar.gz", hash = "sha256:09a1ba8385f0981f6952a2c42788563aa9bbb1554289ba1e62e0bc0f44b8d3b5"},
+    {file = "ansys_sphinx_theme-0.16.0-py3-none-any.whl", hash = "sha256:594061e401c6a038e3e5c8a837e8af361d2c5376d44e024c921504751ff35215"},
+    {file = "ansys_sphinx_theme-0.16.0.tar.gz", hash = "sha256:3fd85b2cfb801bda700ba6fe96e795a93c393fabd80ddda3006b18781c100901"},
 ]
 
 [package.dependencies]
@@ -144,8 +144,8 @@ pydata-sphinx-theme = ">=0.14,<0.15"
 Sphinx = ">=4.2.0"
 
 [package.extras]
-autoapi = ["sphinx-autoapi (==3.0.0a4)", "sphinx-design (==0.5.0)"]
-doc = ["PyGitHub (==2.3.0)", "Sphinx (==7.2.6)", "numpydoc (==1.7.0)", "requests (==2.31.0)", "sphinx-copybutton (==0.5.2)", "sphinx-design (==0.5.0)", "sphinx-jinja (==2.0.2)", "sphinx-notfound-page (==1.0.0)"]
+autoapi = ["sphinx-autoapi (==3.0.0a4)", "sphinx-design (==0.5.0)", "sphinx-jinja (==2.0.2)"]
+doc = ["PyGitHub (==2.3.0)", "Sphinx (==7.3.7)", "numpydoc (==1.7.0)", "requests (==2.31.0)", "sphinx-copybutton (==0.5.2)", "sphinx-design (==0.5.0)", "sphinx-jinja (==2.0.2)", "sphinx-notfound-page (==1.0.0)"]
 
 [[package]]
 name = "babel"
@@ -1093,4 +1093,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "69c1eb2ea91ed26354e29705afd2db46c41827fcaea5cf9c35fef23c806d2c4d"
+content-hash = "23f50aa4f0a719b8d13a8c307dbfde53183d4786562ca44d01a84319d83e039c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,12 +27,12 @@ files = [
 
 [[package]]
 name = "ansys-grantami-bomanalytics"
-version = "2.1.0"
+version = "2.1.1"
 description = "Perform compliance and sustainability analysis on materials data stored in Granta MI."
 optional = false
 python-versions = "<4.0.0,>=3.9.0"
 files = [
-    {file = "ansys_grantami_bomanalytics-2.1.0-py3-none-any.whl", hash = "sha256:f047d07496892b0eade463f85fd0f4ac6b163b66889bd02c75e79143e40a7e97"},
+    {file = "ansys_grantami_bomanalytics-2.1.1-py3-none-any.whl", hash = "sha256:008d66068f2476d5c8a474a1d205968fead1267f186433b3cfc768ae93c162be"},
 ]
 
 [package.dependencies]
@@ -1094,4 +1094,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f5e11d5f37a3dea313bf860f6c50cc9e9138c0146d7c889839376cbca6423a69"
+content-hash = "c473fea437d37ba9af11c0d2c417fab1a282f6eda57e091c9504f166c9d1ee5a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -722,13 +722,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.2"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
+    {file = "requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,13 +60,13 @@ requests = ">=2.26.0,<3.0.0"
 
 [[package]]
 name = "ansys-grantami-jobqueue"
-version = "1.0.0"
+version = "1.0.1"
 description = "A python wrapper for the Granta MI Job Queue API"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "ansys_grantami_jobqueue-1.0.0-py3-none-any.whl", hash = "sha256:8c3dadb571148a5ade3b79d591345d39919ed9d3a256b50baa77e7005bfbda85"},
-    {file = "ansys_grantami_jobqueue-1.0.0.tar.gz", hash = "sha256:f73c0c0a3135e010077ab496ddb4ea13938bc5b2cccd8a5d6c76ac4a44a9f7a4"},
+    {file = "ansys_grantami_jobqueue-1.0.1-py3-none-any.whl", hash = "sha256:346a1889d984d8e359a857083549910caca41911ecb5e9c2b023c8423aa4c6a4"},
+    {file = "ansys_grantami_jobqueue-1.0.1.tar.gz", hash = "sha256:073b64df556577350ece2169238f032b202160f6fff45cabc21eb7a11d96dcce"},
 ]
 
 [package.dependencies]
@@ -1094,4 +1094,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c473fea437d37ba9af11c0d2c417fab1a282f6eda57e091c9504f166c9d1ee5a"
+content-hash = "1eef7edbe76e251b53b7611353557a0acdf397e6f31406c2104761794291caa2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -863,13 +863,13 @@ rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
 name = "sphinx-design"
-version = "0.5.0"
+version = "0.6.0"
 description = "A sphinx extension for designing beautiful, view size responsive web components."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "sphinx_design-0.5.0-py3-none-any.whl", hash = "sha256:1af1267b4cea2eedd6724614f19dcc88fe2e15aff65d06b2f6252cee9c4f4c1e"},
-    {file = "sphinx_design-0.5.0.tar.gz", hash = "sha256:e8e513acea6f92d15c6de3b34e954458f245b8e761b45b63950f65373352ab00"},
+    {file = "sphinx_design-0.6.0-py3-none-any.whl", hash = "sha256:e9bd07eecec82eb07ff72cb50fc3624e186b04f5661270bc7b62db86c7546e95"},
+    {file = "sphinx_design-0.6.0.tar.gz", hash = "sha256:ec8e3c5c59fed4049b3a5a2e209360feab31829346b5f6a0c7c342b894082192"},
 ]
 
 [package.dependencies]
@@ -878,11 +878,12 @@ sphinx = ">=5,<8"
 [package.extras]
 code-style = ["pre-commit (>=3,<4)"]
 rtd = ["myst-parser (>=1,<3)"]
-testing = ["myst-parser (>=1,<3)", "pytest (>=7.1,<8.0)", "pytest-cov", "pytest-regressions"]
-theme-furo = ["furo (>=2023.7.0,<2023.8.0)"]
-theme-pydata = ["pydata-sphinx-theme (>=0.13.0,<0.14.0)"]
-theme-rtd = ["sphinx-rtd-theme (>=1.0,<2.0)"]
-theme-sbt = ["sphinx-book-theme (>=1.0,<2.0)"]
+testing = ["defusedxml", "myst-parser (>=1,<3)", "pytest (>=7.1,<8.0)", "pytest-cov", "pytest-regressions"]
+theme-furo = ["furo (>=2024.5.4,<2024.6.0)"]
+theme-im = ["sphinx-immaterial (>=0.11.11,<0.12.0)"]
+theme-pydata = ["pydata-sphinx-theme (>=0.15.2,<0.16.0)"]
+theme-rtd = ["sphinx-rtd-theme (>=2.0,<3.0)"]
+theme-sbt = ["sphinx-book-theme (>=1.1,<2.0)"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -1093,4 +1094,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "23f50aa4f0a719b8d13a8c307dbfde53183d4786562ca44d01a84319d83e039c"
+content-hash = "f5e11d5f37a3dea313bf860f6c50cc9e9138c0146d7c889839376cbca6423a69"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [{ include = "**/*.py", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-ansys-grantami-bomanalytics = "2.1.0"
+ansys-grantami-bomanalytics = "2.1.1"
 ansys-grantami-bomanalytics-openapi = "3.0.0"
 ansys-grantami-recordlists = "1.2.1"
 ansys-grantami-jobqueue = "1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ python = "^3.9"
 ansys-grantami-bomanalytics = "2.1.1"
 ansys-grantami-bomanalytics-openapi = "3.0.0"
 ansys-grantami-recordlists = "1.2.1"
-ansys-grantami-jobqueue = "1.0.0"
+ansys-grantami-jobqueue = "1.0.1"
 ansys-grantami-serverapi-openapi = "3.0.0"
 
 # Optional documentation dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ optional = true
 
 [tool.poetry.group.doc.dependencies]
 Sphinx = "^7.0.1"
-ansys-sphinx-theme = "^0.15.2"
+ansys-sphinx-theme = "^0.16.0"
 sphinx-copybutton = "^0.5.0"
 sphinx-design = "^0.5.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ optional = true
 Sphinx = "^7.0.1"
 ansys-sphinx-theme = "^0.16.0"
 sphinx-copybutton = "^0.5.0"
-sphinx-design = "^0.5.0"
+sphinx-design = "^0.6.0"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Update dependencies for 2024.2 release. Includes:

* #76: Update pinned JobQueue dependency to 1.0.1
* #77: Update pinned BoM Analytics dependency to 2.1.1

Record lists remains unchanged.

Also includes other updates to address vulnerabilities and to fix bugs in sphinx-gallery extension.