### PR TITLE
Use trusted publisher

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,6 +134,10 @@ jobs:
    name: Release project
    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
    needs: [package, wheelhouse-all]
+   environment: release
+   permissions:
+     id-token: write
+     contents: write
    runs-on: ubuntu-latest
    steps:
      - name: Release to GitHub
@@ -146,8 +150,7 @@ jobs:
        uses: ansys/actions/release-pypi-public@v6
        with:
          library-name: ${{ env.PACKAGE_NAME }}
-         twine-username: __token__
-         twine-token: ${{ secrets.PYPI_TOKEN }}
+         use-trusted-publisher: true
 
   docs-release:
    name: Deploy release docs


### PR DESCRIPTION
Use trusted publisher method of release to public PyPI.

I have also configured the `release` environment to require approval before an associated workflow will run. We can try this once this PR is cherry-picked to the release branch.