### PR TITLE
Improve backwards compatibility documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx_jinja",
+    "sphinx.ext.extlinks",
 ]
 
 # Intersphinx mapping
@@ -70,6 +71,12 @@ numpydoc_validation_checks = {
     # type, unless multiple values are being returned"
 }
 
+extlinks = {
+    "MI_docs": (
+        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v251/en/%s",
+        None,
+    ),
+}
 
 # static path
 html_static_path = ["_static"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -97,7 +97,7 @@ user_agent = (
 )
 
 # Ignore ansys links for linkcheck
-linkcheck_ignore = ["https://www.ansys.com/"]
+linkcheck_ignore = ["https://www.ansys.com/", "https://ansyshelp.ansys.com"]
 
 # sphinx-jinja configuration
 jinja_contexts = {"package_versions_ctx": {}}

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -1,12 +1,18 @@
 Getting started
 ===============
 
-The ``pygranta`` metapackage ensures compatibility between PyGranta packages and
-provides a convenient method for installing packages compatible with a specific
-release of Ansys Granta MI.
+The ``pygranta`` metapackage guarantees mutual compatibility between all PyGranta packages. The packages referenced by a
+``pygranta`` metapackage version are certified to be compatibile with each other and with the corresponding Granta MI
+version.
 
-Most packages require access to an installation of Ansys Granta MI. For more
-information on getting a licensed copy of Ansys products, visit the `Ansys website <https://www.ansys.com/>`_.
+.. note::
+   The ``ansys-grantami-bomanalytics`` and ``ansys-grantami-bomanalytics-openapi`` versions included in the metapackage
+   are compatible with that version of *BoM Analytics Services*, included with Granta MI Restricted
+   Substances and Sustainability Reports. Multiple versions of BoM Analytics Services are compatible with a single
+   version of Granta MI.
+
+Most packages require access to an installation of Ansys Granta MI. For more information on getting a licensed copy of
+Ansys products, visit the `Ansys website <https://www.ansys.com/>`_.
 
 Installing the latest version
 -----------------------------
@@ -17,54 +23,25 @@ To install the latest version of the ``pygranta`` metapackage, run:
 
    pip install pygranta
 
-This installs all the PyGranta packages for the latest released version of Granta MI.
+This installs all the PyGranta packages certified to be compatible with the latest released version of Granta MI.
 
 
 Installing packages compatible with a specific version of Granta MI
 -------------------------------------------------------------------
 
-To install the version of the ``pygranta`` metapackage released with a specific version of Granta MI, provide the
-version number during installation. For example, to install the version released with Granta MI 2023 R2, specify the
+To install the version of the ``pygranta`` metapackage associated with a specific version of Granta MI, provide the
+version number during installation. For example, to install the version associated with Granta MI 2023 R2, specify the
 ``pygranta`` metapackage version ``2023.2.0``:
 
 .. code:: bash
 
    pip install pygranta==2023.2.0
 
-See `Versioning system`_ for more details on PyGranta pacakge version numbers. The PyGranta package versions installed
-with a specific metapackage release are listed on the :doc:`package_versions` page.
+More detailed guidance on selecting package versions which are compatible with specific Granta MI versions is available
+on the :doc:`package_versions` page. This page also includes a list of all PyGranta packages associated with each
+``pygranta`` metapackage version.
 
-.. note::
-   The versions of ansys-grantami-bomanalytics and ansys-grantami-bomanalytics-openapi included in the metapackage
-   are compatible with that version of *BoM Analytics Services*, included with Granta MI Restricted
-   Substances and Sustainability Reports. Multiple versions of BoM Analytics Services are compatible with a single
-   version of Granta MI.
-
-
-Backwards compatibility
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Starting with ``pygranta`` v2025.2.0, PyGranta packages aim to be backwards compatible with all currently-supported
-Granta MI releases. Installing a more modern PyGranta package that has backwards compatibility with your Granta MI
-version allows access to new features and bug fixes.
-
-Full backwards compatibility for all supported Granta MI versions is not guaranteed. Backwards compatibility may
-end earlier than the support window, and new packages may not support older versions of Granta MI. Check the "Getting
-Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
-installation instructions.
-
-For example, to install the latest version of PyGranta RecordLists, run:
-
-.. code:: bash
-
-   pip install ansys-grantami-recordlists
-
-
-To install version 1.3.0, run:
-
-.. code:: bash
-
-   pip install ansys-grantami-recordlists==1.3.0
+See `Versioning system`_ for more details on PyGranta pacakge version numbers.
 
 
 User mode installation

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -1,9 +1,9 @@
 Getting started
 ===============
 
-The ``pygranta`` metapackage guarantees mutual compatibility between all PyGranta packages. The packages referenced by a
-``pygranta`` metapackage version are certified to be compatible with each other and with the corresponding Granta MI
-version.
+The ``pygranta`` metapackage guarantees mutual compatibility between all the PyGranta packages in a specific version.
+That is, the packages referenced by a ``pygranta`` metapackage version are certified to be compatible with each other
+and with the corresponding Granta MI version.
 
 .. note::
    The ``ansys-grantami-bomanalytics`` and ``ansys-grantami-bomanalytics-openapi`` versions included in the metapackage

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -7,9 +7,14 @@ version.
 
 .. note::
    The ``ansys-grantami-bomanalytics`` and ``ansys-grantami-bomanalytics-openapi`` versions included in the metapackage
-   are compatible with that version of *BoM Analytics Services*, included with Granta MI Restricted
-   Substances and Sustainability Reports. Multiple versions of BoM Analytics Services are compatible with a single
-   version of Granta MI.
+   are instead compatible with the corresponding version of *BoM Analytics Services*. BoM Analytics Services is the REST
+   API used by ``ansys-grantami-bomanalytics``, and is provided as part of the *Granta MI Restricted Substances and
+   Sustainability Reports* package.
+
+   Multiple versions of *Granta MI Restricted Substances and Sustainability Reports* are available for a single version
+   of Granta MI. The selected version of *Granta MI Restricted Substances and Sustainability Reports* (and therefore
+   the required version of ``ansys-grantami-bomanalytics``) depends on the *Restricted Substances and Sustainability*
+   database version.
 
 Most packages require access to an installation of Ansys Granta MI. For more information on getting a licensed copy of
 Ansys products, visit the `Ansys website <https://www.ansys.com/>`_.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -9,12 +9,16 @@ version.
    The ``ansys-grantami-bomanalytics`` and ``ansys-grantami-bomanalytics-openapi`` versions included in the metapackage
    are instead compatible with the corresponding version of *BoM Analytics Services*. BoM Analytics Services is the REST
    API used by ``ansys-grantami-bomanalytics``, and is provided as part of the *Granta MI Restricted Substances and
-   Sustainability Reports* package.
+   Sustainability Reports* package. Multiple versions of the reports package are available for a single version of
+   Granta MI.
 
-   Multiple versions of *Granta MI Restricted Substances and Sustainability Reports* are available for a single version
-   of Granta MI. The selected version of *Granta MI Restricted Substances and Sustainability Reports* (and therefore
-   the required version of ``ansys-grantami-bomanalytics``) depends on the *Restricted Substances and Sustainability*
-   database version.
+   The selected version of the reports package, and therefore the required version of ``ansys-grantami-bomanalytics``,
+   depends on the *Restricted Substances and Sustainability* database version.
+
+   Refer to :MI_docs:`the Restricted Substances and Sustainability Install and Configuration guide
+   <RS_and_Sustainability_Install/rs_and_sustainability/planning_your_implementation_rsands.html>` for more details on
+   *Granta MI Restricted Substances and Sustainability Reports* versioning and installation.
+
 
 Most packages require access to an installation of Ansys Granta MI. For more information on getting a licensed copy of
 Ansys products, visit the `Ansys website <https://www.ansys.com/>`_.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -2,7 +2,7 @@ Getting started
 ===============
 
 The ``pygranta`` metapackage guarantees mutual compatibility between all PyGranta packages. The packages referenced by a
-``pygranta`` metapackage version are certified to be compatibile with each other and with the corresponding Granta MI
+``pygranta`` metapackage version are certified to be compatible with each other and with the corresponding Granta MI
 version.
 
 .. note::
@@ -41,7 +41,7 @@ More detailed guidance on selecting package versions which are compatible with s
 on the :doc:`package_versions` page. This page also includes a list of all PyGranta packages associated with each
 ``pygranta`` metapackage version.
 
-See `Versioning system`_ for more details on PyGranta pacakge version numbers.
+See `Versioning system`_ for more details on PyGranta package version numbers.
 
 
 User mode installation

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -105,6 +105,8 @@ using the same command as for Linux.
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.
 
 
+.. _versioning_system:
+
 Versioning system
 -----------------
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -8,12 +8,10 @@ release of Ansys Granta MI.
 Most packages require access to an installation of Ansys Granta MI. For more
 information on getting a licensed copy of Ansys products, visit the `Ansys website <https://www.ansys.com/>`_.
 
-************
-Installation
-************
+Installing the latest version
+-----------------------------
 
-There are several ways of installing PyGranta depending on your use case, but
-the easiest is simply to run this command:
+To install the latest version of the ``pygranta`` metapackage, run:
 
 .. code:: bash
 
@@ -21,12 +19,20 @@ the easiest is simply to run this command:
 
 This installs all the PyGranta packages for the latest released version of Granta MI.
 
-If you are interested in **installing a specific version**, such as ``2023.2.0``, you
-can run a command like this one:
+
+Installing packages compatible with a specific version of Granta MI
+-------------------------------------------------------------------
+
+To install the version of the ``pygranta`` metapackage released with a specific version of Granta MI, provide the
+version number during installation. For example, to install the version released with Granta MI 2023 R2, specify the
+``pygranta`` metapackage version ``2023.2.0``:
 
 .. code:: bash
 
    pip install pygranta==2023.2.0
+
+See `Versioning system`_ for more details on PyGranta pacakge version numbers. The PyGranta package versions installed
+with a specific metapackage release are listed on the :doc:`package_versions` page.
 
 .. note::
    The versions of ansys-grantami-bomanalytics and ansys-grantami-bomanalytics-openapi included in the metapackage
@@ -34,17 +40,35 @@ can run a command like this one:
    Substances and Sustainability Reports. Multiple versions of BoM Analytics Services are compatible with a single
    version of Granta MI.
 
-You can always install PyGranta packages individually by following the installation
-instructions for each package. For example, the instructions for PyGranta
-RecordLists have you install it by running this command:
+
+Backwards compatibility
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with ``pygranta`` v2025.2.0, PyGranta packages aim to be backwards compatible with all currently-supported
+Granta MI releases. Installing a more modern PyGranta package that has backwards compatibility with your Granta MI
+version allows access to new features and bug fixes.
+
+Full backwards compatibility for all supported Granta MI versions is not guaranteed. Backwards compatibility may
+end earlier than the support window, and new packages may not support older versions of Granta MI. Check the "Getting
+Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
+installation instructions.
+
+For example, to install the latest version of PyGranta RecordLists, run:
 
 .. code:: bash
 
    pip install ansys-grantami-recordlists
 
 
+To install version 1.3.0, run:
+
+.. code:: bash
+
+   pip install ansys-grantami-recordlists==1.3.0
+
+
 User mode installation
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 Before installing the ``pygranta`` metapackage in user mode, ensure that you have the
 latest version of `pip <https://pypi.org/project/pip/>`_ by running this command:
@@ -67,8 +91,8 @@ can run a command like this one:
    python -m pip install pygranta==2023.2.0
 
 
-Offline mode installation
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Offline installation
+--------------------
 
 If you lack an internet connection on your installation machine, the
 recommended way of installing the ``pygranta`` metapackage is downloading the
@@ -93,6 +117,7 @@ If you're on Windows with Python 3.12, unzip to a wheelhouse directory and insta
 using the same command as for Linux.
 
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.
+
 
 Versioning system
 -----------------

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -1,17 +1,15 @@
 PyGranta and Granta MI compatibility
 ====================================
 
-PyGranta backwards compatibility
---------------------------------
+PyGranta packages have always been compatible with the Granta MI version they were delivered against.
 
-Starting with ``pygranta`` version 2025.2.0, PyGranta packages aim to be backwards compatible with all Granta MI
-versions supported at the time of release. Installing a more modern PyGranta package that has backwards compatibility
-with your Granta MI version allows access to improvements and bug fixes without having to upgrade Granta MI.
+Starting with pygranta version ``2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
+backwards compatible with all supported Granta MI versions at the time of release. This allows access to improvements
+and bug fixes without having to upgrade Granta MI.
 
-Full backwards compatibility for all supported Granta MI versions is not guaranteed. Backwards compatibility may end
-earlier than the Granta MI support window, and new packages may not support older versions of Granta MI. Check the
-README or "Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version
-and for installation instructions.
+Note: Full backwards compatibility for all supported Granta MI versions is not always guaranteed. Check the README or
+"Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
+installation instructions.
 
 If the latest PyGranta package version does not support the required Granta MI version, either:
 
@@ -19,11 +17,8 @@ If the latest PyGranta package version does not support the required Granta MI v
 * Use the table in the `Package versions`_ section to identify the version of the PyGranta package released with the
   required Granta MI version.
 
-PyGranta forwards compatibility
--------------------------------
-
-Forwards compatibility of PyGranta packages with future Granta MI releases is not guaranteed. PyGranta packages should
-be upgraded following a Granta MI server upgrade.
+In addition, forwards compatibility of PyGranta packages with future Granta MI releases is not guaranteed. PyGranta
+packages should always be upgraded following a Granta MI server upgrade.
 
 
 Package versions
@@ -31,8 +26,7 @@ Package versions
 
 These tables map a PyGranta metapackage version to the individual PyGranta package associated with it. This can be used
 to determine the **minimum** PyGranta package that is compatible with a given version of Granta MI. However, due to
-backwards compatibility, it may be possible to use more modern package versions. See `PyGranta backwards compatibility`_
-for more details.
+backwards compatibility, it may be possible to use more modern package versions.
 
 .. note::
    The ``ansys-grantami-bomanalytics`` and ``ansys-grantami-bomanalytics-openapi`` versions included in the metapackage

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -3,7 +3,7 @@ PyGranta and Granta MI compatibility
 
 PyGranta packages have always been compatible with the Granta MI version they were delivered against.
 
-Starting with ``pygranta 2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
+Starting with PyGranta version ``2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
 backwards compatible with all supported Granta MI versions at the time of release. This allows access to improvements
 and bug fixes without having to upgrade Granta MI.
 

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -6,12 +6,18 @@ PyGranta backwards compatibility
 
 Starting with ``pygranta`` version 2025.2.0, PyGranta packages aim to be backwards compatible with all Granta MI
 versions supported at the time of release. Installing a more modern PyGranta package that has backwards compatibility
-with your Granta MI version allows access to improvements and bug fixes.
+with your Granta MI version allows access to improvements and bug fixes without having to upgrade Granta MI.
 
 Full backwards compatibility for all supported Granta MI versions is not guaranteed. Backwards compatibility may end
 earlier than the Granta MI support window, and new packages may not support older versions of Granta MI. Check the
-"Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
-installation instructions.
+README or "Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version
+and for installation instructions.
+
+If the latest PyGranta package version does not support the required Granta MI version, either:
+
+* Use previous versions of the PyGranta package documentation to check compatibility of previous package versions, or
+* Use the table in the `Package versions`_ section to identify the version of the PyGranta package released with the
+  required Granta MI version.
 
 PyGranta forwards compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -1,14 +1,38 @@
-Package versions
-================
+PyGranta and Granta MI compatibility
+====================================
 
-These tables map a PyGranta metapackage version to the individual PyGranta package included within it. In most cases,
-this can be used to determine which PyGranta package is compatible with a given version of Granta MI.
+PyGranta backwards compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with ``pygranta`` version 2025.2.0, PyGranta packages aim to be backwards compatible with all Granta MI
+versions supported at the time of release. Installing a more modern PyGranta package that has backwards compatibility
+with your Granta MI version allows access to improvements and bug fixes.
+
+Full backwards compatibility for all supported Granta MI versions is not guaranteed. Backwards compatibility may end
+earlier than the Granta MI support window, and new packages may not support older versions of Granta MI. Check the
+"Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
+installation instructions.
+
+PyGranta forwards compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Forwards compatibility of PyGranta packages with future Granta MI releases is not guaranteed. PyGranta packages should
+be upgraded following a Granta MI server upgrade.
+
+
+Package versions
+~~~~~~~~~~~~~~~~
+
+These tables map a PyGranta metapackage version to the individual PyGranta package associated with it. This can be used
+to determine the **minimum** PyGranta package that is compatible with a given version of Granta MI. However, due to
+backwards compatibility, it may be possible to use more modern package versions. See `PyGranta backwards compatibility`_
+for more details.
 
 .. note::
-   The versions of ansys-grantami-bomanalytics and ansys-grantami-bomanalytics-openapi included in a metapackage version
-   are compatible with that version of *BoM Analytics Services*, included with Granta MI Restricted
-   Substances and Sustainability Reports. Multiple versions of BoM Analytics Services are compatible with a single
-   version of Granta MI.
+   The ``ansys-grantami-bomanalytics`` and ``ansys-grantami-bomanalytics-openapi`` versions included in the metapackage
+   are compatible with that version of *BoM Analytics Services*, included with Granta MI Restricted Substances and
+   Sustainability Reports. Multiple versions of BoM Analytics Services are compatible with a single version of Granta
+   MI.
 
 .. jinja:: package_versions_ctx
 

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -2,7 +2,7 @@ PyGranta and Granta MI compatibility
 ====================================
 
 PyGranta backwards compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 Starting with ``pygranta`` version 2025.2.0, PyGranta packages aim to be backwards compatible with all Granta MI
 versions supported at the time of release. Installing a more modern PyGranta package that has backwards compatibility
@@ -20,14 +20,14 @@ If the latest PyGranta package version does not support the required Granta MI v
   required Granta MI version.
 
 PyGranta forwards compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 Forwards compatibility of PyGranta packages with future Granta MI releases is not guaranteed. PyGranta packages should
 be upgraded following a Granta MI server upgrade.
 
 
 Package versions
-~~~~~~~~~~~~~~~~
+----------------
 
 These tables map a PyGranta metapackage version to the individual PyGranta package associated with it. This can be used
 to determine the **minimum** PyGranta package that is compatible with a given version of Granta MI. However, due to

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -5,7 +5,8 @@ PyGranta packages have always been compatible with the Granta MI version they we
 
 Starting with PyGranta version ``2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
 backwards compatible with all supported Granta MI versions at the time of release. This allows access to improvements
-and bug fixes without having to upgrade Granta MI.
+and bug fixes without having to upgrade Granta MI. See :ref:`versioning_system` for how Granta MI and PyGranta version
+numbers are related.
 
 .. note::
    Full backwards compatibility for all supported Granta MI versions is not always guaranteed. Check the README or

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -1,23 +1,20 @@
 PyGranta and Granta MI compatibility
 ====================================
 
-PyGranta packages have always been compatible with the Granta MI version they were delivered against.
+PyGranta packages have always been compatible with the Granta MI version they were delivered against (see
+:ref:`versioning_system`).
 
 Starting with PyGranta version ``2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
 backwards compatible with all supported Granta MI versions at the time of release. This allows access to improvements
-and bug fixes without having to upgrade Granta MI. See :ref:`versioning_system` for how Granta MI and PyGranta version
-numbers are related.
+and bug fixes without having to upgrade Granta MI.
 
 .. note::
    Full backwards compatibility for all supported Granta MI versions is not always guaranteed. Check the README or
    "Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
    installation instructions.
 
-If the latest PyGranta package version does not support the required Granta MI version, either:
-
-* Use previous versions of the PyGranta package documentation to check compatibility of previous package versions, or
-* Use the table in the `Package versions`_ section to identify the version of the PyGranta package released with the
-  required Granta MI version.
+If the latest PyGranta package version does not support the required Granta MI version, use the Package versions table
+below to identify the version of the PyGranta package released with the required Granta MI version.
 
 In addition, forwards compatibility of PyGranta packages with future Granta MI releases is not guaranteed. PyGranta
 packages should always be upgraded following a Granta MI server upgrade.

--- a/doc/source/package_versions.rst
+++ b/doc/source/package_versions.rst
@@ -3,13 +3,14 @@ PyGranta and Granta MI compatibility
 
 PyGranta packages have always been compatible with the Granta MI version they were delivered against.
 
-Starting with pygranta version ``2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
+Starting with ``pygranta 2025.2.0`` (released with Granta MI 2025 R2), where possible, PyGranta packages are
 backwards compatible with all supported Granta MI versions at the time of release. This allows access to improvements
 and bug fixes without having to upgrade Granta MI.
 
-Note: Full backwards compatibility for all supported Granta MI versions is not always guaranteed. Check the README or
-"Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
-installation instructions.
+.. note::
+   Full backwards compatibility for all supported Granta MI versions is not always guaranteed. Check the README or
+   "Getting Started" guide for the individual PyGranta package to confirm the minimum required Granta MI version and for
+   installation instructions.
 
 If the latest PyGranta package version does not support the required Granta MI version, either:
 

--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -6,11 +6,10 @@ User guide
 The ``pygranta`` metapackage itself is not used directly. Instead, it provides a bundle of
 PyGranta packages that are compatible with each other and with a given Granta MI release.
 
-The user guide for each PyGranta package provides general usage information.
+The user guide for each PyGranta package provides usage information specific to that package.
 
-********************
 PyGranta user guides
-********************
+~~~~~~~~~~~~~~~~~~~~
 
 .. grid:: 3
 
@@ -25,3 +24,5 @@ PyGranta user guides
     .. grid-item-card:: PyGranta JobQueue :material-regular:`work_history`
       :link: https://jobqueue.grantami.docs.pyansys.com/version/stable/user_guide/index.html
       :class-title: pyansys-card-title
+
+

--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -9,7 +9,7 @@ PyGranta packages that are compatible with each other and with a given Granta MI
 The user guide for each PyGranta package provides usage information specific to that package.
 
 PyGranta user guides
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 .. grid:: 3
 


### PR DESCRIPTION
Closes #174 

Improve the documentation to describe the backwards compatibility of PyGranta packages.

Also includes a refresh of the Getting Started guide