### PR TITLE
Bump version number to v2025.2.0dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "pygranta"
 description = "Pythonic interfaces to Ansys Granta MI"
-version = "2025.1.0dev0"
+version = "2025.2.0dev0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Bump version number of main branch.

This should have been done shortly after the last release, but is required now since we will soon be creating a release branch.

Closes #172, because only stable releases before the current version number are considered. 
