### PR TITLE
Allow JSON parsing to fail

### DIFF
--- a/doc/list_dependencies.py
+++ b/doc/list_dependencies.py
@@ -91,7 +91,10 @@ def get_documentation_link_from_pypi(library: str, library_version: str) -> Opti
     """Get the documentation link from PyPI for a specific library and version."""
     # Get the PyPI metadata for the library
     resp = requests.get(f"https://pypi.org/pypi/{library}/{library_version}/json")
-    metadata = resp.json()
+    try:
+        metadata = resp.json()
+    except requests.JSONDecodeError:
+        metadata = {}
 
     try:
         doc_url = metadata["info"]["project_urls"]["Documentation"]


### PR DESCRIPTION
Closes #192 

A recent dependabot PR failed because requests failed to parse an empty response to JSON. Since the parsing failed, there is no output to tell us exactly what the URL was that failed to create a response.

This PR allows this particular parsing operation to fail, which should then log a warning with the package/version combination that failed to yield a valid response.

If we merge this, we can rebase the relevant dependabot PR, and hopefully get a better idea of what is going wrong.