### PR TITLE
Prepare 2025.2.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "pygranta"
 description = "Pythonic interfaces to Ansys Granta MI"
-version = "2025.2.0"
+version = "2025.2.1"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Closes https://github.com/ansys/pygranta/issues/170

Update the version number to 2025.2.1

The following PRs have already been cherry-picked onto this release branch:

* https://github.com/ansys/pygranta/pull/187 - 8a001126be5d4cfb7700516fdf5e62c4fa813e02
* https://github.com/ansys/pygranta/pull/205 - f10042074a09c04ec74379a733cb26c327c65c73
* https://github.com/ansys/pygranta/pull/206 - 0b531226ba54ceb17f3aaa465edafd71d33514b4
* https://github.com/ansys/pygranta/pull/207 - dd2a23dfb09709e2abe9a67de49a136beffe0ac3